### PR TITLE
Fix piece display when running compiled/published binaries

### DIFF
--- a/ChessPlatform.csproj
+++ b/ChessPlatform.csproj
@@ -10,8 +10,12 @@
     <ItemGroup>
       <PackageReference Include="Raylib-cs" Version="5.0.0" />
     </ItemGroup>
+
     <ItemGroup>
-	 <Folder Include="src/resources" />
+      <None Update="src\resources\*">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
+
 </Project>
 


### PR DESCRIPTION
Let me add some explanation here:

What you had before worked when using `dotnet run` or running the project from VisualStudio because the resource files where at the same level of the `.csproj` (that's what you define in your code).

To make that work in general (i.e. when you execute your .exe, which lives inside of `bin/etc.`), you need to make sure those files are copied wherever the final binary (.dll or .exe) is copied, so that paths keep matching to what your code defines.